### PR TITLE
add new view for states

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -6,3 +6,4 @@ from flask import Blueprint
 app_views = Blueprint('app_views', __name__, url_prefix='/api/v1')
 
 from api.v1.views.index import *
+from api.v1.views.states import *

--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+"""View for State objects that handles all default RESTFul API actions"""
+from flask import abort, jsonify, request
+from api.v1.views import app_views
+import models
+from models.state import State
+
+
+@app_views.route('/states', strict_slashes=False, methods=['GET'])
+@app_views.route('/states/<state_id>', strict_slashes=False, methods=['GET'])
+def states(state_id=None):
+    """Retrieves the list of all State objects if state_id is None, if not
+    retrieves a State object
+    """
+    if state_id is None:
+        list_obj_state = models.storage.all(State).values()
+        dict_obj_state = [obj.to_dict() for obj in list_obj_state]
+        return jsonify(dict_obj_state), 200
+    obj_state = models.storage.get(State, state_id)
+    if obj_state is None:
+        abort(404)
+    return jsonify(obj_state.to_dict()), 200
+
+
+@app_views.route('/states/<state_id>', strict_slashes=False,
+                 methods=['DELETE'])
+def delete_state(state_id):
+    """Deletes a State object
+
+    Args:
+        state_id: Id of the object to be deleted
+
+    Raises:
+        a: 404 error if the state_id is not linked to any State object
+    """
+    obj_state = models.storage.get(State, state_id)
+    if obj_state is None:
+        abort(404)
+    models.storage.delete(obj_state)
+    models.storage.save()
+    return jsonify({}), 200
+
+
+@app_views.route('/states', strict_slashes=False, methods=['POST'])
+def create_state():
+    """Creates a State object
+    Raises:
+    a: 404 error if:
+        - The HTTP body request is not valid JSON. Message "Not a JSON"
+        - The dictionary doesn’t contain the key "name". Message "Missing name"
+    Returns:
+        [json string]: The new State with the status code 201
+    """
+    new_state_data = request.get_json()
+    if new_state_data is None:
+        abort(404, "Not a JSON")
+    if "name" not in new_state_data.keys():
+        abort(404, "Missing name")
+    new_state = State(**new_state_data)
+    new_state.save()
+    return jsonify(new_state.to_dict()), 201
+
+
+@app_views.route('/states/<state_id>', strict_slashes=False, methods=['PUT'])
+def update_state(state_id):
+    """Updates a state object.
+    Ignore keys: id, created_at and updated_at
+    Args:
+        state_id: Id of the object to be updated
+
+    Raises:
+        a: 404 error if:
+            - The state_id is not linked to any State object.
+            - The HTTP body request is not valid JSON. Message "Not a JSON"
+    Returns:
+        [json string]: The State object with the status code 200
+    """
+    obj_state = models.storage.get(State, state_id)
+    if obj_state is None:
+        abort(404)
+    new_state_data = request.get_json()
+    if new_state_data is None:
+        abort(404, "Not a JSON")
+    for key, value in new_state_data.items():
+        if key not in ['id', 'created_at', 'updated_at']:
+            setattr(obj_state, key, value)
+    obj_state.save()
+    return jsonify(obj_state.to_dict()), 200


### PR DESCRIPTION
A new view was created for the State objects to handle all the default RESTFul API actions and the blueprint in the __init__.py in the views folder was updated with the import of the new view:

In the states.py file in the views folder the following methods were added.

- states(): Handles the GET action of the RESTFul API.
- delete_state(): Handles the DELETE action of the RESTFul API.
- create_state(): Handles the POST action of the RESTFul API
- update_state(): handles RESTFul API PUT action

For more information read the documentation of each method inside the states.py file in the view folder.

Translated with www.DeepL.com/Translator (free version)